### PR TITLE
Edge attrs

### DIFF
--- a/src/Data/DotLang.purs
+++ b/src/Data/DotLang.purs
@@ -1,134 +1,15 @@
 module Data.DotLang where
 
-import Color (Color, toHexString)
+import Data.DotLang.Attr.Edge as Edge
+import Data.DotLang.Attr.Node as Node
+import Data.DotLang.Class (class DotLang, toText)
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
 import Data.String (joinWith)
-import Prelude (class Show, show, ($), (<$>), (<>))
+import Prelude (class Show, ($), (<$>), (<>))
 
 -- | type alias for a Nodes Name
 type Id = String
-
--- | possible node shapes
-data ShapeType
-  = Box | Polygon | Ellipse | Oval | Circle | Point | Egg
-  | Triangle | Plaintext | Plain | Diamond | Trapezium | Parallelogram 
-  | House | Pentagon | Hexagon | Septagon | Octagon | Doublecircle
-  | Doubleoctagon | Tripleoctagon | Invtriangle | Invtrapezium 
-  | Invhouse | Mdiamond | Msquare | Mcircle | Rect | Rectangle | Square
-  | Star | None | Underline | Cylinder | Note | Tab | Folder | Box3d
-  | Component | Promoter | Cds | Terminator | Utr | Primersite | Restrictionsite
-  | Fivepoverhang | Threepoverhang | Noverhang | Assembly | Signature
-  | Insulator | Ribosite | Rnastab | Proteasesite | Proteinstab | Rpromoter
-  | Rarrow | Larrow | Lpromoter
-
-derive instance genericShapeType :: Generic ShapeType _
-
-instance showShapeType :: Show ShapeType where
-  show = genericShow
-
-instance dotLangShape :: DotLang ShapeType where
-  toText Box = "box"
-  toText Polygon = "polygon"
-  toText Ellipse = "ellipse"
-  toText Oval = "oval"
-  toText Circle = "circle"
-  toText Point = "point"
-  toText Egg = "egg"
-  toText Triangle = "triangle"
-  toText Plaintext = "plaintext"
-  toText Plain = "plain"
-  toText Diamond = "diamond"
-  toText Trapezium = "trapezium"
-  toText Parallelogram = "parallelogram"
-  toText House = "house"
-  toText Pentagon = "pentagon"
-  toText Hexagon = "hexagon"
-  toText Septagon = "septagon"
-  toText Octagon = "octagon"
-  toText Doublecircle = "doublecircle"
-  toText Doubleoctagon = "doubleoctagon"
-  toText Tripleoctagon = "tripleoctagon"
-  toText Invtriangle = "invtriangle"
-  toText Invtrapezium = "invtrapezium"
-  toText Invhouse = "invhouse"
-  toText Mdiamond = "mdiamond"
-  toText Msquare = "msquare"
-  toText Mcircle = "mcircle"
-  toText Rect = "rect"
-  toText Rectangle = "rectangle"
-  toText Square = "square"
-  toText Star = "star"
-  toText None = "none"
-  toText Underline = "underline"
-  toText Cylinder = "cylinder"
-  toText Note = "note"
-  toText Tab = "tab"
-  toText Folder = "folder"
-  toText Box3d = "box3d"
-  toText Component = "component"
-  toText Promoter = "promoter"
-  toText Cds = "cds"
-  toText Terminator = "terminator"
-  toText Utr = "utr"
-  toText Primersite = "primersite"
-  toText Restrictionsite = "restrictionsite"
-  toText Fivepoverhang = "fivepoverhang"
-  toText Threepoverhang = "threepoverhang"
-  toText Noverhang = "noverhang"
-  toText Assembly = "assembly"
-  toText Signature = "signature"
-  toText Insulator = "insulator"
-  toText Ribosite = "ribosite"
-  toText Rnastab = "rnastab"
-  toText Proteasesite = "proteasesite"
-  toText Proteinstab = "proteinstab"
-  toText Rpromoter = "rpromoter"
-  toText Rarrow = "Rarrow"
-  toText Larrow = "Larrow"
-  toText Lpromoter = "Lpromoter"
-
-data FillStyle
-  = Filled
-  | Dotted
-  | Invis
-
-derive instance genericFillStyle :: Generic FillStyle _
-
-instance showFillStyle :: Show FillStyle where
-  show = genericShow
-
-instance fillStyleDotLang :: DotLang FillStyle where
-  toText Filled = "filled"
-  toText Dotted = "dotted"
-  toText Invis = "invis"
-
-data Attr
-  = Margin Int
-  | FontColor Color
-  | FontSize Int
-  | Width Int
-  | Label String
-  | Shape ShapeType
-  | Style FillStyle
-  | FillColor Color
-  | PenWidth Number
-
-derive instance genericAttr :: Generic Attr _
-
-instance showAttr :: Show Attr where
-  show = genericShow
-
-instance attrDotLang :: DotLang Attr where
-  toText (Margin i) = "margin="<> show i
-  toText (FontColor s) = "fontcolor=\"" <> toHexString s <> "\""
-  toText (FontSize i) = "fontsize="<> show i
-  toText (Width i) = "width="<> show i
-  toText (Shape t) = "shape="<> (toText t)
-  toText (Style f) = "style="<>(toText f)
-  toText (Label t) = "label="<> show t
-  toText (FillColor c) = "fillcolor=\"" <> toHexString c <> "\""
-  toText (PenWidth i) = "penwidth="<> show i
 
 -- | Dot-Node
 -- | example :
@@ -136,7 +17,7 @@ instance attrDotLang :: DotLang Attr where
 -- | Node "e" [Margin 3, Label "some label"]
 -- | ```
 -- | is turned into: `e [margin=3, label="some label"];`
-data Node = Node Id (Array Attr)
+data Node = Node Id (Array Node.Attr)
 
 
 -- | get a nodes id
@@ -150,7 +31,7 @@ nodeId (Node id _) = id
 -- | change Nodes id to a new one; keeing the old id as the label
 -- | example: `mapNodeId (\a -> a+"!") (Node "e" []) == Node "e!" [Label "e"]`
 changeNodeId :: (Id -> Id) -> Node -> Node
-changeNodeId f (Node id attr) = Node (f id) $ attr <> [Label id]
+changeNodeId f (Node id attr) = Node (f id) $ attr <> [Node.Label id]
 
 derive instance genericNode :: Generic Node _
 
@@ -158,7 +39,7 @@ instance showNode :: Show Node where
   show = genericShow
 
 instance nodeDotLang :: DotLang Node where
-  toText (Node id attrs) = id <> " [" <> (joinWith ", " (toText <$> attrs)) <> "]"
+  toText (Node id attrs) = id <> " [" <> joinWith ", " (toText <$> attrs) <> "]"
 
 
 data EdgeType
@@ -168,7 +49,7 @@ data EdgeType
 
 derive instance genericEdgeType :: Generic EdgeType _
 
-instance showEdgeType :: Show EdgeType where show = genericShow 
+instance showEdgeType :: Show EdgeType where show = genericShow
 
 instance dotLangEdgeType :: DotLang EdgeType where
   toText Forward = "->"
@@ -178,7 +59,7 @@ instance dotLangEdgeType :: DotLang EdgeType where
 -- | egde from id to id
 -- | `toText $ Edge "a" "b"` == `a -> b`
 -- | option for different arrows is missing
-data Edge = Edge EdgeType Id Id
+data Edge = Edge EdgeType Id Id (Array Edge.Attr)
 
 derive instance genericEdge :: Generic Edge _
 
@@ -186,7 +67,7 @@ instance showEdge :: Show Edge where
   show = genericShow
 
 instance dotLangEdge :: DotLang Edge where
-  toText (Edge e id id2) = id <> " " <> (toText e) <> " " <> id2
+  toText (Edge e id id2 attrs) = id <> " " <> (toText e) <> " " <> id2 <> " [" <> joinWith ", " (toText <$> attrs) <> "]"
 
 -- | definition in a graph
 data Definition
@@ -194,20 +75,20 @@ data Definition
   | EdgeDef Edge
   | Subgraph (Array Definition)
 
-node :: Id → Array Attr → Definition
+node :: Id → Array Node.Attr → Definition
 node id attrs = NodeDef $ Node id attrs
 
-edge :: EdgeType → Id → Id → Definition 
-edge t id id2 = EdgeDef $ Edge t id id2
+edge :: EdgeType → Id → Id → Array Edge.Attr → Definition
+edge t id id2 attrs = EdgeDef $ Edge t id id2 attrs
 
 forwardEdge :: Id → Id → Definition
-forwardEdge = edge Forward
+forwardEdge l r = edge Forward l r []
 
 backwardEdge :: Id → Id → Definition
-backwardEdge = edge Backward
+backwardEdge l r = edge Backward l r []
 
 normalEdge :: Id → Id → Definition
-normalEdge = edge NoDir
+normalEdge l r = edge NoDir l r []
 
 infix 5 forwardEdge as ==>
 infix 5 backwardEdge as <==
@@ -237,6 +118,3 @@ graphFromElements n e = DiGraph $ (NodeDef <$> n) <> (EdgeDef <$> e)
 class GraphRepr a where
   toGraph :: a -> Graph
 
--- | `a` is a type that has a representation in the dot language
-class DotLang a where
-  toText :: a -> String

--- a/src/Data/DotLang.purs
+++ b/src/Data/DotLang.purs
@@ -112,7 +112,7 @@ data Attr
   | Shape ShapeType
   | Style FillStyle
   | FillColor Color
-  | PenSize Number
+  | PenWidth Number
 
 derive instance genericAttr :: Generic Attr _
 
@@ -128,7 +128,7 @@ instance attrDotLang :: DotLang Attr where
   toText (Style f) = "style="<>(toText f)
   toText (Label t) = "label="<> show t
   toText (FillColor c) = "fillcolor=\"" <> toHexString c <> "\""
-  toText (PenSize i) = "pensize="<> show i
+  toText (PenWidth i) = "penwidth="<> show i
 
 -- | Dot-Node
 -- | example :

--- a/src/Data/DotLang/Attr.purs
+++ b/src/Data/DotLang/Attr.purs
@@ -1,0 +1,23 @@
+module Data.DotLang.Attr where
+
+import Prelude
+
+import Data.DotLang.Class (class DotLang)
+import Data.Generic.Rep (class Generic)
+import Data.Generic.Rep.Show (genericShow)
+
+data FillStyle
+  = Filled
+  | Dotted
+  | Invis
+
+derive instance genericFillStyle :: Generic FillStyle _
+
+instance showFillStyle :: Show FillStyle where
+  show = genericShow
+
+instance fillStyleDotLang :: DotLang FillStyle where
+  toText Filled = "filled"
+  toText Dotted = "dotted"
+  toText Invis = "invis"
+

--- a/src/Data/DotLang/Attr/Edge.purs
+++ b/src/Data/DotLang/Attr/Edge.purs
@@ -1,0 +1,33 @@
+module Data.DotLang.Attr.Edge where
+
+import Prelude
+
+import Color (Color, toHexString)
+import Data.DotLang.Attr (FillStyle)
+import Data.DotLang.Class (class DotLang, toText)
+import Data.Generic.Rep (class Generic)
+import Data.Generic.Rep.Show (genericShow)
+
+data Attr
+  = Color Color
+  | FontColor Color
+  | FontSize Int
+  | Label String
+  | Style FillStyle
+  | FillColor Color
+  | PenWidth Number
+
+derive instance genericAttr :: Generic Attr _
+
+instance showAttr :: Show Attr where
+  show = genericShow
+
+instance attrDotLang :: DotLang Attr where
+  toText (Color s) = "color=\"" <> toHexString s <> "\""
+  toText (FontColor s) = "fontcolor=\"" <> toHexString s <> "\""
+  toText (FontSize i) = "fontsize="<> show i
+  toText (Style f) = "style="<> toText f
+  toText (Label t) = "label="<> show t
+  toText (FillColor c) = "fillcolor=\"" <> toHexString c <> "\""
+  toText (PenWidth i) = "penwidth="<> show i
+

--- a/src/Data/DotLang/Attr/Node.purs
+++ b/src/Data/DotLang/Attr/Node.purs
@@ -1,0 +1,117 @@
+module Data.DotLang.Attr.Node where
+
+import Prelude
+
+import Color (Color, toHexString)
+import Data.DotLang.Attr (FillStyle)
+import Data.DotLang.Class (class DotLang, toText)
+import Data.Generic.Rep (class Generic)
+import Data.Generic.Rep.Show (genericShow)
+
+data Attr
+  = Color Color
+  | Margin Int
+  | FontColor Color
+  | FontSize Int
+  | Width Int
+  | Label String
+  | Shape ShapeType
+  | Style FillStyle
+  | FillColor Color
+  | PenWidth Number
+
+derive instance genericAttr :: Generic Attr _
+
+instance showAttr :: Show Attr where
+  show = genericShow
+
+instance attrDotLang :: DotLang Attr where
+  toText (Margin i) = "margin="<> show i
+  toText (Color s) = "color=\"" <> toHexString s <> "\""
+  toText (FontColor s) = "fontcolor=\"" <> toHexString s <> "\""
+  toText (FontSize i) = "fontsize="<> show i
+  toText (Width i) = "width="<> show i
+  toText (Shape t) = "shape="<> toText t
+  toText (Style f) = "style="<> toText f
+  toText (Label t) = "label="<> show t
+  toText (FillColor c) = "fillcolor=\"" <> toHexString c <> "\""
+  toText (PenWidth i) = "penwidth="<> show i
+
+-- | possible node shapes
+data ShapeType
+  = Box | Polygon | Ellipse | Oval | Circle | Point | Egg
+  | Triangle | Plaintext | Plain | Diamond | Trapezium | Parallelogram
+  | House | Pentagon | Hexagon | Septagon | Octagon | Doublecircle
+  | Doubleoctagon | Tripleoctagon | Invtriangle | Invtrapezium
+  | Invhouse | Mdiamond | Msquare | Mcircle | Rect | Rectangle | Square
+  | Star | None | Underline | Cylinder | Note | Tab | Folder | Box3d
+  | Component | Promoter | Cds | Terminator | Utr | Primersite | Restrictionsite
+  | Fivepoverhang | Threepoverhang | Noverhang | Assembly | Signature
+  | Insulator | Ribosite | Rnastab | Proteasesite | Proteinstab | Rpromoter
+  | Rarrow | Larrow | Lpromoter
+
+derive instance genericShapeType :: Generic ShapeType _
+
+instance showShapeType :: Show ShapeType where
+  show = genericShow
+
+instance dotLangShape :: DotLang ShapeType where
+  toText Box = "box"
+  toText Polygon = "polygon"
+  toText Ellipse = "ellipse"
+  toText Oval = "oval"
+  toText Circle = "circle"
+  toText Point = "point"
+  toText Egg = "egg"
+  toText Triangle = "triangle"
+  toText Plaintext = "plaintext"
+  toText Plain = "plain"
+  toText Diamond = "diamond"
+  toText Trapezium = "trapezium"
+  toText Parallelogram = "parallelogram"
+  toText House = "house"
+  toText Pentagon = "pentagon"
+  toText Hexagon = "hexagon"
+  toText Septagon = "septagon"
+  toText Octagon = "octagon"
+  toText Doublecircle = "doublecircle"
+  toText Doubleoctagon = "doubleoctagon"
+  toText Tripleoctagon = "tripleoctagon"
+  toText Invtriangle = "invtriangle"
+  toText Invtrapezium = "invtrapezium"
+  toText Invhouse = "invhouse"
+  toText Mdiamond = "mdiamond"
+  toText Msquare = "msquare"
+  toText Mcircle = "mcircle"
+  toText Rect = "rect"
+  toText Rectangle = "rectangle"
+  toText Square = "square"
+  toText Star = "star"
+  toText None = "none"
+  toText Underline = "underline"
+  toText Cylinder = "cylinder"
+  toText Note = "note"
+  toText Tab = "tab"
+  toText Folder = "folder"
+  toText Box3d = "box3d"
+  toText Component = "component"
+  toText Promoter = "promoter"
+  toText Cds = "cds"
+  toText Terminator = "terminator"
+  toText Utr = "utr"
+  toText Primersite = "primersite"
+  toText Restrictionsite = "restrictionsite"
+  toText Fivepoverhang = "fivepoverhang"
+  toText Threepoverhang = "threepoverhang"
+  toText Noverhang = "noverhang"
+  toText Assembly = "assembly"
+  toText Signature = "signature"
+  toText Insulator = "insulator"
+  toText Ribosite = "ribosite"
+  toText Rnastab = "rnastab"
+  toText Proteasesite = "proteasesite"
+  toText Proteinstab = "proteinstab"
+  toText Rpromoter = "rpromoter"
+  toText Rarrow = "Rarrow"
+  toText Larrow = "Larrow"
+  toText Lpromoter = "Lpromoter"

--- a/src/Data/DotLang/Class.purs
+++ b/src/Data/DotLang/Class.purs
@@ -1,0 +1,5 @@
+module Data.DotLang.Class where
+
+-- | `a` is a type that has a representation in the dot language
+class DotLang a where
+  toText :: a -> String

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -3,7 +3,12 @@ module Test.Main where
 import Prelude
 
 import Color.Scheme.MaterialDesign (red)
-import Data.DotLang (Attr(..), Definition(..), FillStyle(..), Graph(..), ShapeType(..), node, toText, (==>))
+import Data.DotLang (Definition(..), EdgeType(..), Graph(..), edge, node, (==>))
+import Data.DotLang.Attr (FillStyle(..))
+import Data.DotLang.Attr.Edge as Edge
+import Data.DotLang.Attr.Node (Attr(..), ShapeType(..))
+import Data.DotLang.Attr.Node as Node
+import Data.DotLang.Class (toText)
 import Effect (Effect)
 import Test.Unit (suite, test)
 import Test.Unit.Assert (equal)
@@ -15,12 +20,12 @@ main = runTest do
     test "basic test" do
       let
         g = DiGraph [
-          node "a" [ Shape Diamond, Style Filled,  FillColor red ],
+          node "a" [ Shape Diamond, Style Filled,  Node.FillColor red ],
           node "b" [],
           "a" ==> "b",
-          "a" ==> "d",
+          edge Forward "a" "d" [ Edge.FillColor red ],
           Subgraph [
             node "d" []
           ]
         ]
-      equal "digraph {a [shape=diamond, style=filled, fillcolor=\"#f44336\"]; b []; a -> b; a -> d; subgraph { d []; }}" (toText g)
+      equal "digraph {a [shape=diamond, style=filled, fillcolor=\"#f44336\"]; b []; a -> b []; a -> d [fillcolor=\"#f44336\"]; subgraph { d []; }}" (toText g)


### PR DESCRIPTION
I've added attributes for edges. I used https://www.graphviz.org/doc/info/attrs.html as a reference for which attributes applied to edges and which applied to nodes. To support different sets of attributes for edges and nodes, I created a module for edge attributes and node attributes. While this is a bit duplicative and required making several new modules, it seemed preferable to something like https://github.com/natefaubion/purescript-variant.