### PR TITLE
Add support for HTML labels

### DIFF
--- a/src/Data/DotLang.purs
+++ b/src/Data/DotLang.purs
@@ -32,7 +32,7 @@ nodeId (Node id _) = id
 -- | change Nodes id to a new one; keeing the old id as the label
 -- | example: `mapNodeId (\a -> a+"!") (Node "e" []) == Node "e!" [Label "e"]`
 changeNodeId :: (Id -> Id) -> Node -> Node
-changeNodeId f (Node id attr) = Node (f id) $ attr <> [Node.Label (Node.TextLabel id)]
+changeNodeId f (Node id attr) = Node (f id) $ attr <> [Node.textLabel id]
 
 derive instance genericNode :: Generic Node _
 

--- a/src/Data/DotLang.purs
+++ b/src/Data/DotLang.purs
@@ -32,7 +32,7 @@ nodeId (Node id _) = id
 -- | change Nodes id to a new one; keeing the old id as the label
 -- | example: `mapNodeId (\a -> a+"!") (Node "e" []) == Node "e!" [Label "e"]`
 changeNodeId :: (Id -> Id) -> Node -> Node
-changeNodeId f (Node id attr) = Node (f id) $ attr <> [Node.Label id]
+changeNodeId f (Node id attr) = Node (f id) $ attr <> [Node.Label (Node.TextLabel id)]
 
 derive instance genericNode :: Generic Node _
 

--- a/src/Data/DotLang.purs
+++ b/src/Data/DotLang.purs
@@ -32,7 +32,7 @@ nodeId (Node id _) = id
 -- | change Nodes id to a new one; keeing the old id as the label
 -- | example: `mapNodeId (\a -> a+"!") (Node "e" []) == Node "e!" [Label "e"]`
 changeNodeId :: (Id -> Id) -> Node -> Node
-changeNodeId f (Node id attr) = Node (f id) $ attr <> [Node.textLabel id]
+changeNodeId f (Node id attr) = Node (f id) $ attr <> [Node.label id]
 
 derive instance genericNode :: Generic Node _
 

--- a/src/Data/DotLang/Attr/Edge.purs
+++ b/src/Data/DotLang/Attr/Edge.purs
@@ -40,3 +40,19 @@ instance attrDotLang :: DotLang Attr where
   toText (Label (HtmlLabel t)) = "label=" <> t
   toText (FillColor c) = "fillcolor=\"" <> toHexString c <> "\""
   toText (PenWidth i) = "penwidth="<> show i
+
+-- |
+-- | ```purescript
+-- | htmlLabel "<table><tr><td>Label</td></tr></table>" -- :: Attr
+-- | ```
+-- | htmlLabel as a part of an attribute of an edge.
+htmlLabel :: String -> Attr
+htmlLabel = HtmlLabel >>> Label
+
+-- |
+-- | ```purescript
+-- | textLabel "..." -- :: Attr
+-- | ```
+-- | textLabel as a part of an attribute of an edge.
+textLabel :: String -> Attr
+textLabel = HtmlLabel >>> Label

--- a/src/Data/DotLang/Attr/Edge.purs
+++ b/src/Data/DotLang/Attr/Edge.purs
@@ -7,14 +7,21 @@ import Data.DotLang.Attr (FillStyle)
 import Data.DotLang.Class (class DotLang, toText)
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
-import Data.Maybe(Maybe(..))
-import Data.String.CodeUnits(charAt)
+
+data LabelValue
+  = TextLabel String
+  | HtmlLabel String
+
+derive instance genericLabel :: Generic LabelValue _
+
+instance showLabel :: Show LabelValue where
+  show = genericShow
 
 data Attr
   = Color Color
   | FontColor Color
   | FontSize Int
-  | Label String
+  | Label LabelValue
   | Style FillStyle
   | FillColor Color
   | PenWidth Number
@@ -29,8 +36,7 @@ instance attrDotLang :: DotLang Attr where
   toText (FontColor s) = "fontcolor=\"" <> toHexString s <> "\""
   toText (FontSize i) = "fontsize="<> show i
   toText (Style f) = "style="<> toText f
-  toText (Label t) = case charAt 0 t of
-                          Just '<' -> "label=" <> t
-                          _ -> "label=" <> show t
+  toText (Label (TextLabel t)) = "label=" <> show t
+  toText (Label (HtmlLabel t)) = "label=" <> t
   toText (FillColor c) = "fillcolor=\"" <> toHexString c <> "\""
   toText (PenWidth i) = "penwidth="<> show i

--- a/src/Data/DotLang/Attr/Edge.purs
+++ b/src/Data/DotLang/Attr/Edge.purs
@@ -53,6 +53,6 @@ htmlLabel = HtmlLabel >>> Label
 -- | ```purescript
 -- | textLabel "..." -- :: Attr
 -- | ```
--- | textLabel as a part of an attribute of an edge.
-textLabel :: String -> Attr
-textLabel = HtmlLabel >>> Label
+-- | label as a part of an attribute of an edge.
+label :: String -> Attr
+label = TextLabel >>> Label

--- a/src/Data/DotLang/Attr/Edge.purs
+++ b/src/Data/DotLang/Attr/Edge.purs
@@ -7,6 +7,8 @@ import Data.DotLang.Attr (FillStyle)
 import Data.DotLang.Class (class DotLang, toText)
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
+import Data.Maybe(Maybe(..))
+import Data.String.CodeUnits(charAt)
 
 data Attr
   = Color Color
@@ -27,7 +29,8 @@ instance attrDotLang :: DotLang Attr where
   toText (FontColor s) = "fontcolor=\"" <> toHexString s <> "\""
   toText (FontSize i) = "fontsize="<> show i
   toText (Style f) = "style="<> toText f
-  toText (Label t) = "label="<> show t
+  toText (Label t) = case charAt 0 t of
+                          Just '<' -> "label=" <> t
+                          _ -> "label=" <> show t
   toText (FillColor c) = "fillcolor=\"" <> toHexString c <> "\""
   toText (PenWidth i) = "penwidth="<> show i
-

--- a/src/Data/DotLang/Attr/Node.purs
+++ b/src/Data/DotLang/Attr/Node.purs
@@ -138,6 +138,6 @@ htmlLabel = HtmlLabel >>> Label
 -- | ```purescript
 -- | textLabel "..." -- :: Attr
 -- | ```
--- | textLabel as a part of an attribute of a node.
-textLabel :: String -> Attr
-textLabel = HtmlLabel >>> Label
+-- | label as a part of an attribute of a node.
+label :: String -> Attr
+label = TextLabel >>> Label

--- a/src/Data/DotLang/Attr/Node.purs
+++ b/src/Data/DotLang/Attr/Node.purs
@@ -130,7 +130,7 @@ instance dotLangShape :: DotLang ShapeType where
 -- | ```purescript
 -- | htmlLabel "<table><tr><td>Label</td></tr></table>" -- :: Attr
 -- | ```
--- | htmlLabel as a part of an attribute of an edge.
+-- | htmlLabel as a part of an attribute of a node.
 htmlLabel :: String -> Attr
 htmlLabel = HtmlLabel >>> Label
 
@@ -138,6 +138,6 @@ htmlLabel = HtmlLabel >>> Label
 -- | ```purescript
 -- | textLabel "..." -- :: Attr
 -- | ```
--- | textLabel as a part of an attribute of an edge.
+-- | textLabel as a part of an attribute of a node.
 textLabel :: String -> Attr
 textLabel = HtmlLabel >>> Label

--- a/src/Data/DotLang/Attr/Node.purs
+++ b/src/Data/DotLang/Attr/Node.purs
@@ -7,6 +7,8 @@ import Data.DotLang.Attr (FillStyle)
 import Data.DotLang.Class (class DotLang, toText)
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
+import Data.Maybe(Maybe(..))
+import Data.String.CodeUnits(charAt)
 
 data Attr
   = Color Color
@@ -33,7 +35,9 @@ instance attrDotLang :: DotLang Attr where
   toText (Width i) = "width="<> show i
   toText (Shape t) = "shape="<> toText t
   toText (Style f) = "style="<> toText f
-  toText (Label t) = "label="<> show t
+  toText (Label t) = case charAt 0 t of
+                          Just '<' -> "label="<> t
+                          _ -> "label=" <> show t
   toText (FillColor c) = "fillcolor=\"" <> toHexString c <> "\""
   toText (PenWidth i) = "penwidth="<> show i
 

--- a/src/Data/DotLang/Attr/Node.purs
+++ b/src/Data/DotLang/Attr/Node.purs
@@ -125,3 +125,19 @@ instance dotLangShape :: DotLang ShapeType where
   toText Rarrow = "Rarrow"
   toText Larrow = "Larrow"
   toText Lpromoter = "Lpromoter"
+
+-- |
+-- | ```purescript
+-- | htmlLabel "<table><tr><td>Label</td></tr></table>" -- :: Attr
+-- | ```
+-- | htmlLabel as a part of an attribute of an edge.
+htmlLabel :: String -> Attr
+htmlLabel = HtmlLabel >>> Label
+
+-- |
+-- | ```purescript
+-- | textLabel "..." -- :: Attr
+-- | ```
+-- | textLabel as a part of an attribute of an edge.
+textLabel :: String -> Attr
+textLabel = HtmlLabel >>> Label

--- a/src/Data/DotLang/Attr/Node.purs
+++ b/src/Data/DotLang/Attr/Node.purs
@@ -7,8 +7,15 @@ import Data.DotLang.Attr (FillStyle)
 import Data.DotLang.Class (class DotLang, toText)
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
-import Data.Maybe(Maybe(..))
-import Data.String.CodeUnits(charAt)
+
+data LabelValue
+  = TextLabel String
+  | HtmlLabel String
+
+derive instance genericLabel :: Generic LabelValue _
+
+instance showLabel :: Show LabelValue where
+  show = genericShow
 
 data Attr
   = Color Color
@@ -16,7 +23,7 @@ data Attr
   | FontColor Color
   | FontSize Int
   | Width Int
-  | Label String
+  | Label LabelValue
   | Shape ShapeType
   | Style FillStyle
   | FillColor Color
@@ -35,9 +42,8 @@ instance attrDotLang :: DotLang Attr where
   toText (Width i) = "width="<> show i
   toText (Shape t) = "shape="<> toText t
   toText (Style f) = "style="<> toText f
-  toText (Label t) = case charAt 0 t of
-                          Just '<' -> "label="<> t
-                          _ -> "label=" <> show t
+  toText (Label (TextLabel t)) = "label=" <> show t
+  toText (Label (HtmlLabel t)) = "label=" <> t
   toText (FillColor c) = "fillcolor=\"" <> toHexString c <> "\""
   toText (PenWidth i) = "penwidth="<> show i
 


### PR DESCRIPTION
Label attribute can have html content. Currently a quote(") is put around the value of the label, if the first character of the label is a '<' then don't quote the value.

https://www.graphviz.org/doc/info/lang.html