### PR TITLE
Add global attributes

### DIFF
--- a/spago.dhall
+++ b/spago.dhall
@@ -13,5 +13,5 @@
   , "strings"
   ]
 , packages = ./packages.dhall
-, sources = [ "src/**/*.purs", "test/**/*.purs" ]
+, sources = [ "src/**/*.purs" ]
 }

--- a/src/Data/DotLang/Attr/Global.purs
+++ b/src/Data/DotLang/Attr/Global.purs
@@ -42,9 +42,48 @@ instance pageDirValueDotLang :: DotLang PageDirValue where
   toText Lb = "LB"
   toText Lt = "LT"
 
+data LabelJustValue = L | R
+
+derive instance Generic LabelJustValue _
+
+instance Show LabelJustValue where
+  show = genericShow
+
+instance DotLang LabelJustValue where
+  toText L = "l"
+  toText R = "r"
+
+data LabelLocValue = T | B
+
+derive instance Generic LabelLocValue _
+
+instance Show LabelLocValue where
+  show = genericShow
+
+instance DotLang LabelLocValue where
+  toText T = "t"
+  toText B = "b"
+
+data StyleValue = Filled | Striped | Rounded
+
+derive instance Generic StyleValue _
+
+instance Show StyleValue where
+  show = genericShow
+
+instance DotLang StyleValue where
+  toText Filled = "filled"
+  toText Striped = "striped"
+  toText Rounded = "rounded"
+
 data Attr
   = RankDir RankDirValue
   | PageDir PageDirValue
+  | Label String
+  | LabelJust LabelJustValue
+  | LabelLoc LabelLocValue
+  | Compound Boolean
+  | Style StyleValue
 
 derive instance genericAttr :: Generic Attr _
 
@@ -54,3 +93,8 @@ instance showAttr :: Show Attr where
 instance attrDotLang :: DotLang Attr where
   toText (RankDir dir) = "rankdir=" <> toText dir
   toText (PageDir dir) = "pagedir=" <> toText dir
+  toText (Label val) = "label=" <> show val
+  toText (LabelJust val) = "labeljust=" <> toText val
+  toText (LabelLoc val) = "labelloc=" <> toText val
+  toText (Compound val) = "compound=" <> show val
+  toText (Style val) = "style=" <> toText val

--- a/src/Data/DotLang/Attr/Node.purs
+++ b/src/Data/DotLang/Attr/Node.purs
@@ -3,14 +3,40 @@ module Data.DotLang.Attr.Node where
 import Prelude
 
 import Color (Color, toHexString)
-import Data.Array (foldMap)
-import Data.DotLang.Attr (FillStyle)
 import Data.DotLang.Class (class DotLang, toText)
 import Data.Generic.Rep (class Generic)
 import Data.Maybe (Maybe(..), maybe)
 import Data.Show.Generic (genericShow)
 import Data.String (joinWith)
 
+data Style
+  = Dashed
+  | Dotted
+  | Solid
+  | Invis
+  | Bold
+  | Filled
+  | Striped
+  | Wedged
+  | Diagonals
+  | Rounded
+
+derive instance Generic Style _
+
+instance Show Style where
+  show = genericShow
+
+instance DotLang Style where
+  toText Dashed = "dashed"
+  toText Dotted = "dotted"
+  toText Solid = "solid"
+  toText Invis = "invis"
+  toText Bold = "bold"
+  toText Filled = "filled"
+  toText Striped = "striped"
+  toText Wedged = "wedged"
+  toText Diagonals = "diagonals"
+  toText Rounded = "rounded"
 
 data LabelValue
   = TextLabel String
@@ -54,7 +80,7 @@ data Attr
   | Width Int
   | Label LabelValue
   | Shape ShapeType
-  | Style FillStyle
+  | Style Style
   | FillColor Color
   | PenWidth Number
 


### PR DESCRIPTION
## Adds some global attributes.

A couple of notes on that:

In this library it's distinguished between "global|node|edge" attributes. However, the graphviz documentation distinguishes between "graph|subgraph|cluster|node|edge". Some of the attributes I added would have been more acurately identified as something other than "global". E.g. "labelloc" would be "edge|node|cluster".

For now I'd argue to keep "global" as an inaccurate bag for "graph|subgraph|cluster" for the following reasons:
- Would mean a larger refactoring to get it right
- The distinction between subgraph & and cluster is difficult to model. A cluster is magically identified when the subgraph id starts with "cluster_".
- Some already existing inhabintants of "global" like "rankdir" are actually only allowed inside graphs. So with this it would have already be possible to produce invalid output when e.g. used inside a subgraph. 

## Makes the node style a node specific type

Some node styles are only valid for nodes. See: https://graphviz.org/docs/attr-types/style/
Thats why a node specific style type replaces the global "FillStyle" 